### PR TITLE
Mobile list-items too large

### DIFF
--- a/css/my_news.css
+++ b/css/my_news.css
@@ -1421,6 +1421,10 @@
         margin: 30px 0px 20px 10%;
     }
 
+    .mcas-url {
+        font-size: 18px;
+    }
+
 }
 
 @media only screen and (max-width: 390px) {


### PR DESCRIPTION
index page css change: .mcas-url font-size:18px, too large on mobile before